### PR TITLE
Observe Msls config option

### DIFF
--- a/MslsMenu.php
+++ b/MslsMenu.php
@@ -71,7 +71,7 @@ class MslsMenu {
 				$mslsmenu = '';
 
 				$obj = new MslsOutput;
-				foreach ( $obj->get( (int) $options->mslsmenu_display ) as $item ) {
+				foreach ( $obj->get( (int) $options->mslsmenu_display, false, (int) $options->only_with_translation ) as $item ) {
 					$mslsmenu .= $options->mslsmenu_before_item . $item . $options->mslsmenu_after_item;
 				}
 


### PR DESCRIPTION
The "Show only links with a translation" of the Multisite Language Switcher Plugin is not observed.