### PR TITLE
Adds workflow and execution logic for the plugin check

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
 /.wordpress-org
 /.git
 /.github
+/bin
 /reports
 /tests
 .distignore

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,22 @@
+name: Plugin Check
+on: # rebuild any PRs and main branch changes
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Composer dependencies
+        run: composer install --no-dev --no-interaction --optimize-autoloader
+      - name: Build
+        run:  composer run-script build
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: './mslsmenu'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 .idea/
 vendor/
 reports/
+mslsmenu/
+mslsmenu.zip

--- a/MslsMenu.php
+++ b/MslsMenu.php
@@ -8,7 +8,7 @@
  *
  * Plugin Name: MslsMenu
  * Requires Plugins: multisite-language-switcher
- * Version: 2.5.0
+ * Version: 2.5.1
  * Plugin URI: https://wordpress.org/plugins/mslsmenu/
  * Description: Adds the Multisite Language Switcher to the primary-nav-menu
  * Author: Dennis Ploetner

--- a/MslsMenu.php
+++ b/MslsMenu.php
@@ -1,32 +1,35 @@
 <?php
-
-/*
-Plugin Name: MslsMenu
-Requires Plugins: multisite-language-switcher
-Plugin URI: https://github.com/lloc/MslsMenu
-Description: Adds the Multisite Language Switcher to the primary-nav-menu
-Version: 2.5.0
-Author: Dennis Ploetner
-Author URI: http://lloc.de/
-Text Domain: mslsmenu
-*/
-
-/*
-Copyright 2014  Dennis Ploetner  (email : re@lloc.de)
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License, version 2, as
-published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+/**
+ * MslsMenu
+ *
+ * @copyright Copyright (C) 2011-2022, Dennis Ploetner, re@lloc.de
+ * @license http://www.gnu.org/licenses/gpl-2.0.html GNU General Public License, version 2 or later
+ * @wordpress-plugin
+ *
+ * Plugin Name: MslsMenu
+ * Requires Plugins: multisite-language-switcher
+ * Version: 2.5.0
+ * Plugin URI: https://wordpress.org/plugins/mslsmenu/
+ * Description: Adds the Multisite Language Switcher to the primary-nav-menu
+ * Author: Dennis Ploetner
+ * Author URI: http://lloc.de/
+ * Text Domain: mslsmenu
+ * Domain Path: /languages/
+ * License: GPLv2 or later
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 
 declare( strict_types=1 );
 

--- a/bin/git-release.sh
+++ b/bin/git-release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+PLUGIN_NAME="mslsmenu"
+BUILD_PATH="$PROJECT_ROOT/$PLUGIN_NAME"
+ZIP_ARCHIVE="$PROJECT_ROOT/$PLUGIN_NAME.zip"
+
+rm -f $ZIP_ARCHIVE
+rm -rf $BUILD_PATH && mkdir $BUILD_PATH
+
+rsync -arvp --exclude-from=$PROJECT_ROOT/.distignore $PROJECT_ROOT/ $BUILD_PATH/
+cd $PROJECT_ROOT && zip -r $ZIP_ARCHIVE $PLUGIN_NAME

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-2.0-or-later",
   "homepage": "https://it.wordpress.org/plugins/mslsmenu/",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "composer/installers": "~1.9.0"
   },
   "require-dev": {
@@ -21,7 +21,11 @@
   "scripts": {
     "test": "vendor/bin/pest",
     "coverage": "php -d xdebug.mode=coverage vendor/bin/pest --coverage",
-    "analyze": "vendor/bin/phpstan analyze"
+    "analyze": "vendor/bin/phpstan analyze",
+    "git-release": "bin/git-release.sh",
+    "build": [
+      "@git-release"
+    ]
   },
   "authors": [
     {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: multilingual, multisite, language, switcher, menu
 Requires at least: 5.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 2.5.0
+Stable tag: 2.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,10 @@ But this can lead to fatal errors if you don't know much about PHP, or maybe the
 4. Output in the primary nav menu
 
 == Changelog ==
+
+= 2.5.1 =
+* plugin check integration added
+* missing license problem addressed
 
 = 2.5.0 =
 * WordPress 6.6 tested


### PR DESCRIPTION
This PR adds the GitHub Action for the plugin check. It also addresses the 'no license' issue identified by the plugin check.